### PR TITLE
Use project-relative paths for data files

### DIFF
--- a/transcricall/README.md
+++ b/transcricall/README.md
@@ -40,9 +40,14 @@ flowchart LR
 ### Instalación (local)
 
 ```bash
-cd /workspace/transcricall
+cd transcricall
 python -m venv .venv
+# Linux / macOS
 source .venv/bin/activate
+# Windows PowerShell
+.\.venv\Scripts\Activate.ps1
+# Windows CMD
+.\.venv\Scripts\activate.bat
 pip install -r requirements.txt
 # (Opcional) descarga automática de modelo pequeño en español
 export ALLOW_AUTO_DOWNLOAD=1

--- a/transcricall/backend/database.py
+++ b/transcricall/backend/database.py
@@ -3,7 +3,19 @@ from sqlalchemy.orm import sessionmaker
 from contextlib import contextmanager
 import os
 
-DB_PATH = os.getenv("DB_PATH", "/workspace/transcricall/transcricall.db")
+
+# Resolve a default database path relative to this file instead of relying on a
+# hardcoded absolute location.  The previous implementation pointed to
+# ``/workspace/transcricall`` which fails on systems where the repository is
+# named differently (for example ``TranscriCall``).  By deriving the path from
+# the package location we ensure the database can always be created.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DEFAULT_DB_PATH = os.path.join(BASE_DIR, "transcricall.db")
+DB_PATH = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+
+# Make sure the parent directory exists so SQLite can create the DB file.
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 
 engine = create_engine(

--- a/transcricall/backend/inference.py
+++ b/transcricall/backend/inference.py
@@ -6,6 +6,12 @@ import zipfile
 from typing import Tuple, Dict
 
 
+# Base directory of the project (one level up from this file).  Using a
+# relative path avoids hard-coding ``/workspace/transcricall`` which breaks when
+# the repository directory has a different name or casing.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
 class Transcriber:
     def __init__(self, engine: str = "vosk", language: str = "es", model_path: str = ""):
         self.engine = engine
@@ -91,7 +97,14 @@ def ensure_default_model(engine: str, language: str, model_path: str = ""):
 
 
 def default_model_path(engine: str, language: str) -> str:
-    base = "/workspace/transcricall/models"
+    """Return the default directory where models are stored.
+
+    The previous implementation hardcoded ``/workspace/transcricall`` which
+    fails if the repository lives elsewhere or uses a different name.  By
+    basing the path on ``BASE_DIR`` we make it portable.
+    """
+
+    base = os.path.join(BASE_DIR, "models")
     if engine == "vosk":
         sub = {
             "es": "vosk-model-small-es",

--- a/transcricall/backend/websocket_manager.py
+++ b/transcricall/backend/websocket_manager.py
@@ -15,9 +15,14 @@ class ConnectionManager:
 
     async def disconnect(self, websocket: WebSocket):
         async with self._lock:
-            for clients in self._agent_to_clients.values():
+            empty_keys = []
+            for agent, clients in self._agent_to_clients.items():
                 if websocket in clients:
                     clients.remove(websocket)
+                if agent != "all" and not clients:
+                    empty_keys.append(agent)
+            for agent in empty_keys:
+                del self._agent_to_clients[agent]
 
     async def subscribe(self, websocket: WebSocket, agent_id: str):
         async with self._lock:
@@ -27,6 +32,8 @@ class ConnectionManager:
         async with self._lock:
             if agent_id in self._agent_to_clients and websocket in self._agent_to_clients[agent_id]:
                 self._agent_to_clients[agent_id].remove(websocket)
+                if agent_id != "all" and not self._agent_to_clients[agent_id]:
+                    del self._agent_to_clients[agent_id]
 
     async def broadcast(self, agent_id: str, message):
         async with self._lock:
@@ -42,5 +49,7 @@ class ConnectionManager:
         if to_remove:
             async with self._lock:
                 for ws in to_remove:
-                    for clients in self._agent_to_clients.values():
+                    for agent, clients in list(self._agent_to_clients.items()):
                         clients.discard(ws)
+                        if agent != "all" and not clients:
+                            del self._agent_to_clients[agent]


### PR DESCRIPTION
## Summary
- derive SQLite database path from package directory and ensure its parent folder exists
- compute default model path based on project root instead of hardcoded `/workspace/transcricall`
- document Windows virtualenv activation and correct requirements file location
- remove stale websocket connections to avoid memory leaks

## Testing
- `pip install -r transcricall/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a168ad730832680afda2255241cc4